### PR TITLE
Interpreter value ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +396,7 @@ dependencies = [
  "lazy_static",
  "pest",
  "pest_derive",
+ "rustc-hash",
  "rustyline",
  "sysinfo",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ rustyline = "15.0.0"
 colored = "2.2.0"
 sysinfo = "0.33.0"
 uuid = { version = "1", features = ["v4"] }
+rustc-hash = "2.1.0"

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -502,7 +502,8 @@ impl ValueModifier for StackVariableModifier {
     fn get(&self, stack: &CallStack) -> ValueRef {
         stack
             .get_variable(&self.name)
-            .expect(format!("Variable '{}' not found", self.name).as_str())
+            //.expect(format!("Variable '{}' not found", self.name).as_str())
+            .unwrap()
             .clone()
     }
 }
@@ -1056,9 +1057,9 @@ fn evaluate_function_call(
                 let global_environment_ref = global_environment.borrow();
                 let fun = fun
                     .or_else(|| global_environment_ref.get_function(name))
-                    .expect(format!("function `{}` doesn't exist", name).as_str());
+                    .unwrap();
 
-                stack.borrow_mut().create_frame_push(format!("function_call_{}", name));
+                stack.borrow_mut().create_frame_push("".to_string());
                 let r = evaluate_function(
                     stack,
                     arguments.first().unwrap(),
@@ -1327,8 +1328,9 @@ pub fn evaluate_node(
                 .map(|v| match v {
                     Value::Boolean(ok) => Some(*ok),
                     _ => None,
-                })
-                .expect(format!("non boolean expression: {:?}", condition.as_ref()).as_str());
+                }).unwrap();
+
+            //.expect(format!("non boolean expression: {:?}", condition.as_ref()).as_str());
             if ok {
                 for n in body {
                     let val = evaluate_node(n, stack, global_environment);
@@ -1496,7 +1498,8 @@ pub fn evaluate_node(
             let v = stack
                 .borrow()
                 .get_variable(name)
-                .expect(format!("variable '{}' does not exist", name).as_str());
+                .unwrap();
+            //.expect(format!("variable '{}' does not exist", name).as_str());
             // let res = Rc::clone(&v);
             // drop(stack_ref);
             v.clone()

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1200,20 +1200,18 @@ fn evaluate_function_call(
         Node::FunctionCall {
             name, arguments, ..
         } => {
-            // println!("eval func call={}", name);
-            // if name == "sk_debug_mem" {
-            //     Profiling::sk_debug_mem_sysinfo();
-            //     Profiling::sk_debug_mem_programmatic(stack.borrow().deref());
-            //     return ValueRef::stack(Value::Undefined);
-            // }
-            //
+            if name == "sk_debug_mem" {
+                Profiling::sk_debug_mem_sysinfo();
+                Profiling::sk_debug_mem_programmatic(stack.borrow().deref());
+                return ValueRef::stack(Value::Undefined);
+            }
+
             if name == "sk_debug_stack" {
                 Profiling::sk_debug_stack(stack.borrow().deref());
                 return ValueRef::stack(Value::Undefined);
             }
 
             let value_opt = { stack.borrow_mut().get_closure(name) };
-            // stack.borrow_mut().current_frame_mut().add_closure(name.to_string(), value_opt.clone());
             let res = if let Some(value) = value_opt {
                 Some(evaluate_closure(
                     &value,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1309,7 +1309,7 @@ pub fn evaluate_node(
             }
 
             if *lambda {
-                ValueRef::stack(Value::Closure {
+                ValueRef::heap(Value::Closure {
                     function: func_def,
                     env: stack.borrow().current_frame().env.clone(),
                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::fs;
 use std::io;
 use std::ops::Deref;
-
+use std::time::Instant;
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();
     let type_checker_enabled: bool = true;
@@ -29,7 +29,10 @@ fn main() -> io::Result<()> {
             }
         };
     }
+    let now = Instant::now();
     let result = interpreter::evaluate(&node);
+    let elapsed = now.elapsed();
+    println!("Elapsed: {:.2?}", elapsed);
     // let res_ref = result.borrow();
     // println!("Result:");
     // println!("{}", res_ref);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ fn main() -> io::Result<()> {
         };
     }
     let result = interpreter::evaluate(&node);
-    let res_ref = result.borrow();
-    println!("Result:");
-    println!("{}", res_ref);
+    // let res_ref = result.borrow();
+    // println!("Result:");
+    // println!("{}", res_ref);
     Ok(())
 }


### PR DESCRIPTION
1. ValueRef: stack, heap
2. VariableStorage: small, large
3. removed ValueModifier: extra allocations.
4. added cache for closures.

```
function fib(n: int): int {
    if (n <= 1) {
        return n;
    }
    return fib(n - 1) + fib(n - 2);
}

print(fib(30));
```


Elapsed: 826.22ms

still slow but better than before: 11.85s
so 10x faster. but still very slow... 
